### PR TITLE
Reader: read files in package safe way

### DIFF
--- a/src/old_icelandic_dictionary/dictionary.py
+++ b/src/old_icelandic_dictionary/dictionary.py
@@ -1,12 +1,11 @@
-import os
 from . import reader
 from enum import Enum
 from typing import NamedTuple, Tuple
 
 
 class DictionaryPath(str, Enum):
-    DEFAULT = os.path.dirname(__file__) + "/resources/default.json"
-    NO_MARKUP = os.path.dirname(__file__) + "/resources/no-markup.json"
+    DEFAULT = "default.json"
+    NO_MARKUP = "no-markup.json"
 
 
 class DictionaryEntry(NamedTuple):
@@ -14,8 +13,8 @@ class DictionaryEntry(NamedTuple):
     definitions: Tuple[str, ...]
 
 
-def get_dictionary(path: str) -> Tuple[DictionaryEntry, ...]:
-    raw_data = reader.read_json(path)
+def get_dictionary(path: DictionaryPath) -> Tuple[DictionaryEntry, ...]:
+    raw_data = reader.read_json(path.value)
 
     return tuple(
         DictionaryEntry(raw_entry["word"], raw_entry["definitions"])

--- a/src/old_icelandic_dictionary/reader.py
+++ b/src/old_icelandic_dictionary/reader.py
@@ -1,9 +1,11 @@
+from importlib.resources import open_text
 from json import load
 from typing import Any
+from . import resources
 
 
 def read_json(path: str) -> Any:
-    file = open(path)
+    file = open_text(resources, path)
     raw_data = load(file)
     file.close()
 

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -7,7 +7,7 @@ def test_default_dictionary_has_correct_length() -> None:
 
 
 def test_default_dictionary_has_expected_content() -> None:
-    result =old_icelandic_dictionary.get_default()
+    result = old_icelandic_dictionary.get_default()
 
     assert result[14].word == "afbindi"
     assert result[14].definitions[0] == "n. <i>constipation</i>."


### PR DESCRIPTION
Using __file__ does not always work when installing packages. Use importlib instead