### PR TITLE
Setup: include static json files in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,5 @@ setuptools.setup(
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.9",
+    package_data={"": ["**/*.json"]},
 )


### PR DESCRIPTION
Apparently packaging process drops data files unless otherwise stated.